### PR TITLE
Remove pip packages installation.

### DIFF
--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -28,13 +28,6 @@
   with_items: "{{ install_aur_packages }}"
   tags: install_aur
 
-- name: Install pip packages
-  pip:
-    name: "{{ item }}"
-    state: present
-  with_items: "{{ install_pip_packages }}"
-  become: yes
-
 - name: Install rbenv
   git:
     repo: https://github.com/rbenv/rbenv.git

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -26,6 +26,7 @@ install_packages:
   - glide
   - gnupg
   - go
+  - httpie
   - htop
   - i3lock
   - i3status
@@ -60,7 +61,10 @@ install_packages:
   - pulseaudio
   - pulseaudio-alsa
   - python
+  - python-jedi
   - python-pip
+  - python-pylint
+  - python-virtualenv
   - rsync
   - rxvt-unicode
   - scrot
@@ -96,6 +100,7 @@ install_packages:
   - zsh
 
 install_aur_packages:
+  - aws-cli-git
   - dropbox
   - kubectl-bin
   - kubernetes-helm
@@ -106,13 +111,6 @@ install_aur_packages:
   - tmux-xpanes
   - visual-studio-code-bin
   - zoom
-
-install_pip_packages:
-  - virtualenv
-  - httpie
-  - awscli
-  - jedi
-  - pylint
 
 configuration_user_dirs:
   - "{{ ansible_user_dir }}/bin"


### PR DESCRIPTION
Installing pip packages with sudo causes these to conflict with the
distro's packages files. In order to simplify and avoid these errors,
we'll now install everything using the distro package manager and
install any pip packages with a non-root user, probably using virtualenv
or a similar tool.