### PR TITLE
Use protonvpn through openvpn-client

### DIFF
--- a/roles/configuration/tasks/network.yml
+++ b/roles/configuration/tasks/network.yml
@@ -87,3 +87,12 @@
         enabled: yes
         state: started
   become: yes
+
+- name: Configure sudoers for network tools
+  template:
+    src: templates/sudoers-network.j2
+    dest: /etc/sudoers.d/network
+    owner: root
+    mode: 0440
+    validate: /usr/bin/visudo -cf %s
+  become: yes

--- a/roles/configuration/tasks/system.yml
+++ b/roles/configuration/tasks/system.yml
@@ -114,15 +114,6 @@
   become: yes
   when: configuration_system_dpms_disabled
 
-- name: Configure sudoers for network tools
-  template:
-    src: templates/sudoers-network.j2
-    dest: /etc/sudoers.d/network
-    owner: root
-    mode: 0440
-    validate: /usr/bin/visudo -cf %s
-  become: yes
-
 - name: Configure Logitech webcam zoom
   file:
     src: files/system/99-logitech-default-zoom.rules

--- a/roles/configuration/tasks/user.yml
+++ b/roles/configuration/tasks/user.yml
@@ -41,9 +41,7 @@
     name: dropbox
     user: yes
     enabled: yes
-    state: started
   when: '"dropbox" in install_host_aur_packages'
-  tags: tests
 
 - name: Enable redshift
   systemd:

--- a/roles/configuration/templates/sudoers-network.j2
+++ b/roles/configuration/templates/sudoers-network.j2
@@ -1,3 +1,4 @@
 # Ansible managed, do not edit!
 {{ ansible_user_id }} {{ ansible_hostname }} = (root) NOPASSWD: /usr/bin/netctl
-{{ ansible_user_id }} {{ ansible_hostname }} = (root) NOPASSWD: SETENV: /usr/bin/protonvpn
+{{ ansible_user_id  }} {{ ansible_hostname }} = (root) NOPASSWD: /usr/bin/systemctl restart openvpn-client@protonvpn.service
+{{ ansible_user_id  }} {{ ansible_hostname }} = (root) NOPASSWD: /usr/bin/systemctl stop openvpn-client@protonvpn.service

--- a/vars/loki.yml
+++ b/vars/loki.yml
@@ -12,6 +12,7 @@ install_host_packages:
 
 install_host_aur_packages:
   - dropbox
+  - openvpn-update-resolv-conf-git
   - perl-musicbrainz-discid
   - perl-webservice-musicbrainz
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -66,6 +66,7 @@ install_packages:
   - nmap
   - openbsd-netcat
   - openssh
+  - openvpn
   - otf-font-awesome
   - patch
   - pavucontrol
@@ -123,7 +124,6 @@ install_aur_packages:
   - kubectl-bin
   - kubernetes-helm
   - minikube-bin
-  - protonvpn-cli-ng
   - redshift-minimal
   - restic
   - slack-desktop


### PR DESCRIPTION
The newer version of the protonvpn-cli tool depends on NetworkManager,
which is not available on my systems. To circumvent this, openvpn is now
used instead.